### PR TITLE
chore: performance tweaks to wallaby config

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -6,11 +6,13 @@ module.exports = function (wallaby) {
     files: [
       { pattern: 'node_modules/es6-shim/es6-shim.js', instrument: false },
       { pattern: 'node_modules/systemjs/dist/system-polyfills.js', instrument: false },
+      { pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', instrument: false },
       { pattern: 'node_modules/systemjs/dist/system.js', instrument: false },
-      { pattern: 'node_modules/reflect-metadata/Reflect.js', instrument: false },
-      { pattern: 'node_modules/zone.js/dist/zone.js', instrument: false },
-      { pattern: 'node_modules/zone.js/dist/long-stack-trace-zone.js', instrument: false },
-      { pattern: 'node_modules/zone.js/dist/jasmine-patch.js', instrument: false },
+      { pattern: 'node_modules/rxjs/bundles/Rx.js', instrument: false },
+      { pattern: 'node_modules/angular2/bundles/angular2.dev.js', instrument: false },
+      { pattern: 'node_modules/angular2/bundles/http.dev.js', instrument: false },
+      { pattern: 'node_modules/angular2/bundles/router.dev.js', instrument: false },
+      { pattern: 'node_modules/angular2/bundles/testing.dev.js', instrument: false },
 
       { pattern: appBase + '+(app|api)/**/*+(ts|html|css)', load: false },
       { pattern: appBase + 'app/**/*.spec.ts', ignore: true }
@@ -61,20 +63,30 @@ module.exports = function (wallaby) {
         barrelConfig[appPackage + '/' + barrelName] = {
           format: 'register',
           defaultExtension: 'js',
-          main: 'index'
+          main: 'index',
+          meta: {
+            '*': {
+              scriptLoad: true
+            }
+          }
         };
         return barrelConfig;
       }, {});
-
+      packages[appPackage] = packages['src/client/api'] = packages['a2-in-memory-web-api'] = {
+        format: 'register',
+        defaultExtension: 'js',
+        meta: {
+          '*': {
+            scriptLoad: true
+          }
+        }
+      };
       System.config({
-        defaultJSExtensions: true,
         packages: packages,
         paths: {
           'npm:*': 'node_modules/*'
         },
         map: {
-          'angular2': 'npm:angular2',
-          'rxjs': 'npm:rxjs',
           'a2-in-memory-web-api': 'npm:a2-in-memory-web-api'
         }
       });
@@ -82,9 +94,9 @@ module.exports = function (wallaby) {
       var promises = [];
 
       Promise.all([
-        System.import('angular2/testing'),
-        System.import('angular2/platform/testing/browser')
-      ])
+          System.import('angular2/testing'),
+          System.import('angular2/platform/testing/browser')
+        ])
         .then(function (results) {
           var testing = results[0];
           var browser = results[1];


### PR DESCRIPTION
- Using bundles for ng-2 components.
- Using `angular2-polyfills` instead of zone.js and reflect-metadata.